### PR TITLE
feature : Refresh Token

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,19 +1,23 @@
+import { HttpStatus } from '@nestjs/common';
+import { UserService } from './../user/user.service';
 import { Test } from '@nestjs/testing';
 import { ModuleMocker, MockFunctionMetadata } from 'jest-mock';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { GithubCodeDto } from './dto/auth.dto';
+import { Response } from 'express';
 
 const moduleMocker = new ModuleMocker(global);
 
 describe('AuthController', () => {
   let authController: AuthController;
   let authService: AuthService;
+  let userService: UserService;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [AuthService],
+      providers: [AuthService, UserService],
     })
       .useMocker((token) => {
         if (token === AuthService) {
@@ -21,6 +25,16 @@ describe('AuthController', () => {
             signIn: jest.fn(),
             signUp: jest.fn(),
             getAuthCategory: jest.fn(),
+            getCookiesWithJwtRefreshToken: jest.fn(),
+            getCookiesForLogOut: jest.fn(),
+            getJwtAccessToken: jest.fn(),
+            isRefreshTokenExpirationDateHalfPast: jest.fn(),
+          };
+        }
+        if (token === UserService) {
+          return {
+            saveRefreshToken: jest.fn(),
+            deleteRefreshToken: jest.fn(),
           };
         }
         if (typeof token === 'function') {
@@ -35,50 +49,109 @@ describe('AuthController', () => {
 
     authController = moduleRef.get<AuthController>(AuthController);
     authService = moduleRef.get<AuthService>(AuthService);
+    userService = moduleRef.get<UserService>(UserService);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should be defined', () => {
-    expect(authController).toBeDefined();
-  });
-
   describe('signIn()', () => {
-    it('SUCCESS : should return an object { accessToken, userName, isMember : true }', async () => {
-      const githubCodeDto = { code: 'github_code' };
-      const expectedResult = {
+    const githubCodeDto = { code: 'github_code' };
+
+    const mockCookieConstants = {
+      domain: process.env.COOKIE_CLIENT_DOMAIN || 'localhost',
+      path: '/',
+      httpOnly: true,
+      maxAge: 1000,
+      sameSite: 'none' as const,
+      secure: true,
+      signed: true,
+    };
+
+    const mockCookieWithJwtRefreshToken = {
+      refreshToken: 'test',
+      ...mockCookieConstants,
+    };
+
+    const res: Response = {
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+    } as any;
+
+    it('SUCCESS : Should set refresh token cookie and return an object { accessToken, userName, isMember : true }, if user is a member', async () => {
+      const userInfo = {
         isMember: true,
         userName: 'user',
         accessToken: 'jwt-token',
+        userId: 1,
       };
-      authService.signIn = jest.fn().mockResolvedValue(expectedResult);
+      const { userId, ...expectedResult } = userInfo;
 
-      const result = await authController.signIn(githubCodeDto);
+      jest.spyOn(authService, 'signIn').mockResolvedValue(userInfo);
+      jest
+        .spyOn(authService, 'getCookiesWithJwtRefreshToken')
+        .mockResolvedValue(mockCookieWithJwtRefreshToken);
+      jest.spyOn(userService, 'saveRefreshToken').mockResolvedValue(undefined);
+
+      await authController.signIn(githubCodeDto, res);
 
       expect(authService.signIn).toHaveBeenCalledWith(githubCodeDto);
-      expect(result).toBe(expectedResult);
+      expect(authService.getCookiesWithJwtRefreshToken).toHaveBeenCalledWith(
+        userId,
+      );
+      expect(userService.saveRefreshToken).toHaveBeenCalledTimes(1);
+
+      expect(res.cookie).toHaveBeenCalledWith(
+        'Refresh',
+        mockCookieWithJwtRefreshToken.refreshToken,
+        mockCookieConstants,
+      );
+
+      expect(res.json).toHaveBeenCalledWith(expectedResult);
     });
 
-    it('FAILURE : should return an object { isMember : false, userName, githubId }', async () => {
-      const githubCodeDto: GithubCodeDto = { code: 'github_code' };
+    it('FAILURE : Should return http exception 401 and an object { isMember : false, userName, githubId }', async () => {
       const expectedResult = {
         isMember: false,
         userName: 'user',
         githubId: 123456,
       };
-      authService.signIn = jest.fn().mockResolvedValue(expectedResult);
 
-      const result = await authController.signIn(githubCodeDto);
+      jest.spyOn(authService, 'signIn').mockResolvedValue(expectedResult);
+
+      await authController.signIn(githubCodeDto, res);
 
       expect(authService.signIn).toHaveBeenCalledWith(githubCodeDto);
-      expect(result).toBe(expectedResult);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.UNAUTHORIZED);
+      expect(res.json).toHaveBeenCalledWith(expectedResult);
     });
   });
 
   describe('signUp()', () => {
-    it('SUCCESS : should return accessToken', async () => {
+    const res: Response = {
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+    } as any;
+
+    const mockCookieConstants = {
+      domain: process.env.COOKIE_CLIENT_DOMAIN || 'localhost',
+      path: '/',
+      httpOnly: true,
+      maxAge: 1000,
+      sameSite: 'none' as const,
+      secure: true,
+      signed: true,
+    };
+
+    const mockCookieWithJwtRefreshToken = {
+      refreshToken: 'test',
+      ...mockCookieConstants,
+    };
+
+    it('SUCCESS : Should set refresh token cookie and return accessToken', async () => {
       const signUpDto = {
         userName: 'user',
         githubId: 123456,
@@ -86,18 +159,176 @@ describe('AuthController', () => {
         careerId: 1,
         isKorean: true,
       };
-      const expectedResult = { accessToken: 'jwt-token' };
-      authService.signUp = jest.fn().mockResolvedValue(expectedResult);
 
-      const result = await authController.signUp(signUpDto);
+      const expectedResult = { accessToken: 'jwt-token', userId: 1 };
+
+      jest.spyOn(authService, 'signUp').mockResolvedValue(expectedResult);
+      jest
+        .spyOn(authService, 'getCookiesWithJwtRefreshToken')
+        .mockResolvedValue(mockCookieWithJwtRefreshToken);
+      jest.spyOn(userService, 'saveRefreshToken').mockResolvedValue(undefined);
+
+      await authController.signUp(signUpDto, res);
 
       expect(authService.signUp).toHaveBeenCalledWith(signUpDto);
-      expect(result).toBe(expectedResult);
+      expect(authService.getCookiesWithJwtRefreshToken).toHaveBeenCalledWith(
+        expectedResult.userId,
+      );
+      expect(userService.saveRefreshToken).toHaveBeenCalledTimes(1);
+
+      expect(res.cookie).toHaveBeenCalledWith(
+        'Refresh',
+        mockCookieWithJwtRefreshToken.refreshToken,
+        mockCookieConstants,
+      );
+
+      expect(res.json).toHaveBeenCalledWith({
+        accessToken: expectedResult.accessToken,
+      });
+    });
+  });
+
+  describe('signOut()', () => {
+    const mockReq = { user: { id: 1 } };
+    const mockRes: Response = {
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+    } as any;
+
+    const mockCookieConstants = {
+      domain: process.env.COOKIE_CLIENT_DOMAIN || 'localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'none' as const,
+      secure: true,
+      signed: true,
+    };
+
+    it('SUCCESS : Should set empty refresh token cookie', async () => {
+      jest
+        .spyOn(authService, 'getCookiesForLogOut')
+        .mockResolvedValue(mockCookieConstants);
+
+      jest
+        .spyOn(userService, 'deleteRefreshToken')
+        .mockResolvedValue(undefined);
+
+      await authController.signOut(mockReq, mockRes);
+
+      expect(authService.getCookiesForLogOut).toHaveBeenCalled();
+      expect(userService.deleteRefreshToken).toHaveBeenCalledWith(
+        mockReq.user.id,
+      );
+
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        'Refresh',
+        '',
+        mockCookieConstants,
+      );
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'LOG_OUT_COMPLETED',
+      });
+    });
+  });
+
+  describe('refresh()', () => {
+    const mockReq = {
+      signedCookies: { Refresh: 'test' },
+      user: { id: 1, userName: 'test' },
+    };
+
+    const mockRes = {
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as any;
+
+    const accessToken = 'test';
+
+    const mockCookieConstants = {
+      domain: process.env.COOKIE_CLIENT_DOMAIN || 'localhost',
+      path: '/',
+      httpOnly: true,
+      maxAge: 1000,
+      sameSite: 'none' as const,
+      secure: true,
+      signed: true,
+    };
+
+    const mockCookieWithJwtRefreshToken = {
+      refreshToken: 'test',
+      ...mockCookieConstants,
+    };
+
+    it('SUCCESS : Should set new refresh token cookie and return accessToken, if refresh token should be regenerated ', async () => {
+      jest
+        .spyOn(authService, 'getJwtAccessToken')
+        .mockResolvedValue(accessToken);
+
+      jest
+        .spyOn(authService, 'isRefreshTokenExpirationDateHalfPast')
+        .mockResolvedValue(true);
+
+      jest
+        .spyOn(authService, 'getCookiesWithJwtRefreshToken')
+        .mockResolvedValue(mockCookieWithJwtRefreshToken);
+
+      jest.spyOn(userService, 'saveRefreshToken').mockResolvedValue(undefined);
+
+      await authController.refresh(mockReq, mockRes);
+
+      expect(authService.getJwtAccessToken).toHaveBeenCalledWith(
+        mockReq.user.id,
+        mockReq.user.userName,
+      );
+
+      expect(authService.isRefreshTokenExpirationDateHalfPast).toBeCalledWith(
+        mockCookieWithJwtRefreshToken.refreshToken,
+      );
+
+      expect(authService.getCookiesWithJwtRefreshToken).toBeCalledWith(
+        mockReq.user.id,
+      );
+      expect(userService.saveRefreshToken).toBeCalledWith(
+        mockCookieWithJwtRefreshToken.refreshToken,
+        mockReq.user.id,
+      );
+
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        'Refresh',
+        mockCookieWithJwtRefreshToken.refreshToken,
+        mockCookieConstants,
+      );
+
+      expect(mockRes.json).toHaveBeenCalledWith({ accessToken });
+    });
+
+    it('SUCCESS : Should return accessToken, not set cookie ', async () => {
+      jest
+        .spyOn(authService, 'getJwtAccessToken')
+        .mockResolvedValue(accessToken);
+
+      jest
+        .spyOn(authService, 'isRefreshTokenExpirationDateHalfPast')
+        .mockResolvedValue(false);
+
+      await authController.refresh(mockReq, mockRes);
+
+      expect(authService.getJwtAccessToken).toHaveBeenCalledWith(
+        mockReq.user.id,
+        mockReq.user.userName,
+      );
+
+      expect(authService.isRefreshTokenExpirationDateHalfPast).toBeCalledWith(
+        mockCookieWithJwtRefreshToken.refreshToken,
+      );
+
+      expect(mockRes.json).toHaveBeenCalledWith({ accessToken });
     });
   });
 
   describe('getAuthCategory()', () => {
-    it('SUCCESS : should return an object { fields : Field[], careers : Career[] }', async () => {
+    it('SUCCESS : Should return an object { fields : Field[], careers : Career[] }', async () => {
       const expectedResult = { fields: [], careers: [] };
       authService.getAuthCategory = jest.fn().mockResolvedValue(expectedResult);
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -73,6 +73,6 @@ import { RankerProfileRepository } from '../rank/rankerProfile.repository';
     UserRepository,
     RankerProfileRepository,
   ],
-  exports: [AuthService, AuthRepository],
+  exports: [AuthService, AuthRepository, JwtStrategy, JwtRefreshStrategy],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,4 +1,6 @@
-import { jwtConstants } from './constants';
+import { RankerProfileOutput } from './../rank/dto/rankerProfile.dto';
+import { User } from './../entities/User';
+import { jwtConstants, cookieConstants } from './constants';
 import { GithubCodeDto, SignUpWithUserNameDto } from './dto/auth.dto';
 import { RankerProfile } from './../entities/RankerProfile';
 import { Field } from './../entities/Field';
@@ -87,7 +89,6 @@ describe('AuthService', () => {
         if (token === UserRepository) {
           return {
             getUserIdByGithubId: jest.fn(),
-            createUser: jest.fn(),
           };
         }
         if (typeof token === 'function') {
@@ -120,24 +121,23 @@ describe('AuthService', () => {
   });
 
   describe('signIn()', () => {
+    // Given
     const githubCode: GithubCodeDto = { code: 'github_code' };
     const githubAccessToken = 'github_access_token';
     const githubUserInfo = { id: 123456, login: 'user' };
-    const user = { id: 123, githubId: 123456 };
     const jwtToken = 'jwt-token';
 
     beforeEach(() => {
-      userService.getGithubAccessToken = jest
-        .fn()
+      jest
+        .spyOn(userService, 'getGithubAccessToken')
         .mockResolvedValue(githubAccessToken);
-      userService.getByGithubAccessToken = jest
-        .fn()
+      jest
+        .spyOn(userService, 'getByGithubAccessToken')
         .mockResolvedValue(githubUserInfo);
-      userService.getByGithubId = jest.fn().mockResolvedValue(user);
-      jwtService.sign = jest.fn().mockReturnValue(jwtToken);
     });
 
     it('SUCCESS : should return an object { isMember : true, accessToken, userName }', async () => {
+      // Given
       const expectedResult = {
         isMember: true,
         userName: githubUserInfo.login,
@@ -145,27 +145,17 @@ describe('AuthService', () => {
         userId: 123,
       };
 
+      const user = new User();
+      user.id = 123;
+
+      jest.spyOn(userService, 'getByGithubId').mockResolvedValue(user);
+      jest.spyOn(authService, 'getJwtAccessToken').mockResolvedValue(jwtToken);
+
+      // When
       const result = await authService.signIn(githubCode);
 
+      // Then
       expect(result).toEqual(expectedResult);
-    });
-
-    it('FAILURE : should return an object {isMember: false, userName, githubId} when the user is not registered', async () => {
-      userService.getByGithubId = jest.fn().mockResolvedValue(undefined);
-      const expectedResult = {
-        isMember: false,
-        userName: githubUserInfo.login,
-        githubId: githubUserInfo.id,
-      };
-
-      const result = await authService.signIn(githubCode);
-
-      expect(result).toEqual(expectedResult);
-    });
-
-    it('Should call the UserService methods with the correct parameters', async () => {
-      await authService.signIn(githubCode);
-
       expect(userService.getGithubAccessToken).toHaveBeenCalledWith(
         githubCode.code,
       );
@@ -175,23 +165,35 @@ describe('AuthService', () => {
       expect(userService.getByGithubId).toHaveBeenCalledWith(githubUserInfo.id);
     });
 
-    it('Should call the JwtService method with the correct parameters', async () => {
-      await authService.signIn(githubCode);
+    it('FAILURE : should return an object {isMember: false, userName, githubId} when the user is not registered', async () => {
+      // Given
+      const expectedResult = {
+        isMember: false,
+        userName: githubUserInfo.login,
+        githubId: githubUserInfo.id,
+      };
 
-      expect(jwtService.sign).toHaveBeenCalledWith(
-        {
-          userId: 123,
-          userName: githubUserInfo.login,
-        },
-        {
-          expiresIn: `${jwtConstants.jwtExpiresIn}s`,
-          secret: jwtConstants.jwtSecret,
-        },
+      const user = undefined;
+
+      jest.spyOn(userService, 'getByGithubId').mockResolvedValue(user);
+
+      // When
+      const result = await authService.signIn(githubCode);
+
+      // Then
+      expect(result).toEqual(expectedResult);
+      expect(userService.getGithubAccessToken).toHaveBeenCalledWith(
+        githubCode.code,
       );
+      expect(userService.getByGithubAccessToken).toHaveBeenCalledWith(
+        githubAccessToken,
+      );
+      expect(userService.getByGithubId).toHaveBeenCalledWith(githubUserInfo.id);
     });
   });
 
   describe('signUp()', () => {
+    // Given
     const signUpDataWithUserName: SignUpWithUserNameDto = {
       userName: 'user',
       githubId: 123456,
@@ -201,85 +203,49 @@ describe('AuthService', () => {
     };
 
     const { userName, ...signUpData } = signUpDataWithUserName;
-    const user = { id: 1, ...signUpData };
+    const user = new User();
+    user.id = 1;
+    user.githubId = 12345;
     const jwtToken = 'jwtToken';
+    const rankerProfile = new RankerProfileOutput();
 
     beforeEach(() => {
-      userService.createUser = jest.fn().mockResolvedValue(undefined);
-      userService.getByGithubId = jest.fn().mockResolvedValue(user);
-      jwtService.sign = jest.fn().mockReturnValue(jwtToken);
-      rankService.checkRanker = jest.fn().mockResolvedValue(undefined);
+      jest.spyOn(userService, 'createUser').mockResolvedValue(undefined);
+      jest.spyOn(userService, 'getByGithubId').mockResolvedValue(user);
+      jest.spyOn(authService, 'getJwtAccessToken').mockResolvedValue(jwtToken);
+      jest.spyOn(rankService, 'checkRanker').mockResolvedValue(undefined);
       userRepository.getUserIdByGithubId = jest.fn().mockResolvedValue(user.id);
-      rankerProfileRepository.getRankerProfile = jest.fn().mockResolvedValue({
-        profileImage: 'profileImage',
-        blog: 'blog',
-        email: 'email',
-        company: 'company',
-        region: 'region',
-        userId: user.id,
-      });
+      rankerProfileRepository.getRankerProfile = jest
+        .fn()
+        .mockResolvedValue(rankerProfile);
       rankerProfileRepository.updateRankerProfile = jest
         .fn()
         .mockResolvedValue(undefined);
     });
 
-    it('SUCCESS : should create a new user, sign a JWT token, and update the ranker profile and return an object { accessToken: jwtToken }', async () => {
+    it('SUCCESS : should create a new user, sign a JWT token, and update the ranker profile and return an object { accessToken: jwtToken, userId : userId }', async () => {
+      // When
       const result = await authService.signUp(signUpDataWithUserName);
-      expect(result).toEqual({ accessToken: jwtToken, userId: 1 });
-    });
 
-    it('Should call the UserService methods with the correct parameters', async () => {
-      await authService.signUp(signUpDataWithUserName);
-
+      // Then
+      expect(result).toEqual({ accessToken: jwtToken, userId: user.id });
       expect(userService.createUser).toHaveBeenCalledWith(signUpData);
       expect(userService.getByGithubId).toHaveBeenCalledWith(
         signUpData.githubId,
       );
-    });
-
-    it('Should call the JwtService methods with the correct parameters', async () => {
-      await authService.signUp(signUpDataWithUserName);
-
-      expect(jwtService.sign).toHaveBeenCalledWith(
-        {
-          userId: user.id,
-          userName: userName,
-        },
-        {
-          expiresIn: `${jwtConstants.jwtExpiresIn}s`,
-          secret: jwtConstants.jwtSecret,
-        },
+      expect(authService.getJwtAccessToken).toHaveBeenCalledWith(
+        user.id,
+        userName,
       );
-    });
-
-    it('Should call the RankService methods with the correct parameters', async () => {
-      await authService.signUp(signUpDataWithUserName);
-
-      expect(rankService.checkRanker).toHaveBeenCalledWith(userName);
-    });
-
-    it('Should call the UserRepository methods with the correct parameters', async () => {
-      await authService.signUp(signUpDataWithUserName);
-
+      expect(rankService.checkRanker).toHaveBeenCalledTimes(1);
       expect(userRepository.getUserIdByGithubId).toHaveBeenCalledWith(
         user.githubId,
       );
-    });
-
-    it('Should call the RankerProfileRepository methods with the correct parameters', async () => {
-      await authService.signUp(signUpDataWithUserName);
-
       expect(rankerProfileRepository.getRankerProfile).toHaveBeenCalledWith(
         userName,
       );
-      expect(rankerProfileRepository.updateRankerProfile).toHaveBeenCalledWith(
-        userName,
-        'profileImage',
-        'blog',
-        'email',
-        'company',
-        'region',
-        user.id,
+      expect(rankerProfileRepository.updateRankerProfile).toHaveBeenCalledTimes(
+        1,
       );
     });
   });
@@ -291,10 +257,115 @@ describe('AuthService', () => {
         .fn()
         .mockResolvedValue(expectedResult);
 
-      const result = await authRepository.getAuthCategory();
+      const result = await authService.getAuthCategory();
 
       expect(authRepository.getAuthCategory).toHaveBeenCalledWith();
       expect(result).toBe(expectedResult);
+    });
+  });
+
+  describe('getJwtAccessToken()', () => {
+    it('SUCCESS : Should return jwtToken', async () => {
+      // Given
+      const payload = { userId: 1, userName: 'test' };
+      const jwtToken = 'test';
+      const jwtOptions = {
+        expiresIn: `${jwtConstants.jwtExpiresIn}s`,
+        secret: jwtConstants.jwtSecret,
+      };
+      jest.spyOn(jwtService, 'sign').mockReturnValue(jwtToken);
+
+      // When
+      const result = await authService.getJwtAccessToken(
+        payload.userId,
+        payload.userName,
+      );
+
+      // Then
+      expect(result).toBe(jwtToken);
+      expect(jwtService.sign).toHaveBeenCalledWith(payload, jwtOptions);
+    });
+  });
+
+  describe('getCookiesWithJwtRefreshToken()', () => {
+    it('SUCCESS : Should return cookies With refreshToken ', async () => {
+      // Given
+      const userId = 1;
+      const payload = { userId };
+      const refreshToken = 'test';
+      const jwtOptions = {
+        secret: jwtConstants.jwtRefreshSecret,
+        expiresIn: `${jwtConstants.jwtRefreshExpiresIn}s`,
+      };
+
+      jest.spyOn(jwtService, 'sign').mockReturnValue(refreshToken);
+
+      const expectedResult = { refreshToken, ...cookieConstants };
+
+      // When
+      const result = await authService.getCookiesWithJwtRefreshToken(userId);
+
+      // Then
+      expect(result).toEqual(expectedResult);
+      expect(jwtService.sign).toHaveBeenCalledWith(payload, jwtOptions);
+    });
+  });
+
+  describe('isRefreshTokenExpirationDateHalfPast()', () => {
+    it('SUCCESS : If refreshToken expiration date more than half past, should return true ', async () => {
+      // Given
+      const refreshToken = 'test';
+      const payload = {
+        exp: Date.now() + (+jwtConstants.jwtRefreshExpiresIn * 1000) / 3,
+      };
+
+      const jwtOptions = {
+        secret: jwtConstants.jwtSecret,
+      };
+      jest.spyOn(jwtService, 'verify').mockReturnValue(payload);
+
+      // When
+      const result = await authService.isRefreshTokenExpirationDateHalfPast(
+        refreshToken,
+      );
+
+      // Then
+      expect(result).toBe(true);
+      expect(jwtService.verify).toHaveBeenCalledWith(refreshToken, jwtOptions);
+    });
+
+    it('SUCCESS : If refreshToken expiration date less than half past, should return true ', async () => {
+      // Given
+      const refreshToken = 'test';
+      const payload = {
+        exp: Date.now() + (+jwtConstants.jwtRefreshExpiresIn * 1000 * 2) / 3,
+      };
+      const jwtOptions = {
+        secret: jwtConstants.jwtSecret,
+      };
+      jest.spyOn(jwtService, 'verify').mockReturnValue(payload);
+
+      // When
+      const result = await authService.isRefreshTokenExpirationDateHalfPast(
+        refreshToken,
+      );
+
+      // Then
+      expect(result).toBe(false);
+      expect(jwtService.verify).toHaveBeenCalledWith(refreshToken, jwtOptions);
+    });
+  });
+
+  describe('getCookiesForLogOut()', () => {
+    it('SUCCESS : Should return refreshOptions', async () => {
+      // Given
+      const { maxAge, ...refreshOptions } = cookieConstants;
+
+      // When
+      const result = await authService.getCookiesForLogOut();
+
+      // Then
+      expect(result).toEqual(refreshOptions);
     });
   });
 });

--- a/src/auth/dto/auth-res.dto.ts
+++ b/src/auth/dto/auth-res.dto.ts
@@ -3,6 +3,13 @@ import { ApiProperty, PickType } from '@nestjs/swagger';
 import { Career } from './../../entities/Career';
 import { Field } from './../../entities/Field';
 
+/**
+ * @author MyeongSeok
+ * @description 로그인 성공 시 응답 객체의 DTO입니다.
+ * @param isMember 회원 유무
+ * @param userName github user name
+ * @param accessToken jwt
+ */
 export class AuthSignInOkResDto {
   /**
    * 로그인 요청한 유저가 회원인지 아닌지를 나타냅니다.
@@ -40,6 +47,13 @@ export class AuthSignInOkResDto {
   readonly accessToken: string;
 }
 
+/**
+ * @author MyeongSeok
+ * @description 회원이 아닌 유저가 로그인을 시도했을 때 실패 응답 객체의 DTO입니다.
+ * @param isMember 회원 유무
+ * @param userName github user name
+ * @param githubId github user id
+ */
 export class AuthSignInUnauthorizedResDto extends PickType(AuthSignInOkResDto, [
   'userName',
 ] as const) {
@@ -66,6 +80,10 @@ export class AuthSignInUnauthorizedResDto extends PickType(AuthSignInOkResDto, [
   readonly githubId: number;
 }
 
+/**
+ * @author MyeongSeok
+ * @description 잘못된 깃허브 코드 사용으로 인한 로그인 실패 시 응답 객체의 DTO입니다.
+ */
 export class AuthSignInWrongCodeDto {
   /**
    * @example 400
@@ -110,10 +128,18 @@ export class AuthSignInWrongCodeDto {
   readonly path: string;
 }
 
+/**
+ * @author MyeongSeok
+ * @description 회원가입 성공 시 응답 객체의 DTO입니다.
+ */
 export class AuthSignUpCreatedDto extends PickType(AuthSignInOkResDto, [
   'accessToken',
 ] as const) {}
 
+/**
+ * @author MyeongSeok
+ * @description 회원가입 시 유저에게 받아야 하는 정보의 카테고리를 반환하는 응답객체의 DTO입니다.
+ */
 export class AuthCategoryOkDto {
   /**
    * 유저의 개발분야를 나타냅니다.
@@ -159,3 +185,26 @@ export class AuthCategoryOkDto {
   })
   readonly career: Career[];
 }
+
+/**
+ * @author MyeongSeok
+ * @description 로그아웃 성공 시 응답 객체의 DTO입니다.
+ */
+export class SignOutOkDto {
+  /**
+   * 로그아웃 성공 메시지입니다.
+   * @example LOG_OUT_COMPLETED
+   */
+  @ApiProperty({
+    description: '로그아웃 성공 메시지입니다.',
+    example: 'LOG_OUT_COMPLETED',
+    required: true,
+  })
+  readonly message: string;
+}
+
+/**
+ * @author MyeongSeok
+ * @description 엑세스 토큰 재발급 성공 시 응답 객체의 DTO입니다.
+ */
+export class RefreshOkDto extends AuthSignUpCreatedDto {}

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -4,6 +4,10 @@ import { IsBoolean, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { Type, Exclude, Expose } from 'class-transformer';
 import { Post } from 'src/entities/Post';
 
+/**
+ * @author MyeongSeok
+ * @description 깃허브 엑세스 토큰을 발급 받기 위해 필요한 github code 입니다.
+ */
 export class GithubCodeDto {
   /**
    * github access token을 얻기 위한 github code 입니다.
@@ -18,7 +22,16 @@ export class GithubCodeDto {
   readonly code: string;
 }
 
-export class SignUpDto {
+/**
+ * @author MyeongSeok
+ * @description 회원가입 시 필요한 정보를 받는 req DTO 입니다.
+ * @param githubId github user id
+ * @param fieldId 유저의 개발 분야 id
+ * @param careerId 유저의 개발 경력 id
+ * @param isKorean 한국인 유무
+ * @param userName github user name
+ */
+export class SignUpWithUserNameDto {
   /**
    * 유저의 github userId 입니다.
    * @example 12345
@@ -70,9 +83,7 @@ export class SignUpDto {
   @Type(() => Boolean)
   @IsBoolean()
   readonly isKorean: boolean;
-}
 
-export class SignUpWithUserNameDto extends SignUpDto {
   /**
    * 유저의 github userName입니다.
    * @example userName
@@ -89,6 +100,7 @@ export class SignUpWithUserNameDto extends SignUpDto {
 
 export class AuthorizedUser {
   readonly id: number;
+  readonly userName: string;
   readonly idsOfPostsCreatedByUser?: Post[];
   readonly idsOfPostLikedByUser?: number[];
   readonly idsOfCommentsCreatedByUser?: Comment[];

--- a/src/auth/guard/jwt-auth-optional.guard.ts
+++ b/src/auth/guard/jwt-auth-optional.guard.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+
+/**
+ * @author Songhyun
+ *
+ */
 @Injectable()
 export class OptionalAuthGuard extends AuthGuard('jwt') {
   handleRequest(err, user, info) {

--- a/src/auth/guard/jwt-auth.guard.ts
+++ b/src/auth/guard/jwt-auth.guard.ts
@@ -1,5 +1,10 @@
 import { AuthGuard } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 
+/**
+ * @author MyeongSeok
+ * @description 인가가 필요한 기능에 사용하는 auth guard입니다. 인가된 유저라면 상태 유지정보를 포함한 user 객체를 req 객체에 주입합니다.
+ * @example user = { id:1, userName: 'user', idsOfPostsCreatedByUser :[1,2], idsOfPostLikedByUser:[1,2], idsOfCommentsCreatedByUser::[1,2], idsOfCommentLikedByUser:[1,2] }
+ */
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/auth/guard/jwt-refresh.guard.ts
+++ b/src/auth/guard/jwt-refresh.guard.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
+/**
+ * @author MyeongSeok
+ * @description refresh token을 검증하고 user 객체(id, name)를 req객체에 주입하는 guard입니다.
+ */
 @Injectable()
 export class JwtRefreshGuard extends AuthGuard('jwt-refresh-token') {}

--- a/src/auth/strategy/jwt-refresh.strategy.ts
+++ b/src/auth/strategy/jwt-refresh.strategy.ts
@@ -1,3 +1,4 @@
+import { RankerProfileRepository } from './../../rank/rankerProfile.repository';
 import { jwtConstants } from './../constants';
 import { UserService } from './../../user/user.service';
 import { Strategy, ExtractJwt } from 'passport-jwt';
@@ -28,6 +29,11 @@ export class JwtRefreshStrategy extends PassportStrategy(
       throw new HttpException('FORBIDDEN', HttpStatus.FORBIDDEN);
 
     const { userId } = payload;
-    return this.userService.getUserIfRefreshTokenMatches(refreshToken, userId);
+
+    const user = this.userService.getUserIfRefreshTokenMatches(
+      refreshToken,
+      userId,
+    );
+    return user;
   }
 }

--- a/src/auth/strategy/jwt.strategy.ts
+++ b/src/auth/strategy/jwt.strategy.ts
@@ -19,6 +19,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   }
 
   async validate(payload: any): Promise<AuthorizedUser> {
+    console.log('payload: ', payload);
     const { userId, userName } = payload;
 
     const userNameInDb = await this.rankerProfileRepository.getUserNameByUserId(
@@ -42,10 +43,12 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
 
     const user = {
       id: userId,
+      userName,
       idsOfPostsCreatedByUser,
       idsOfPostLikedByUser,
       idsOfCommentsCreatedByUser,
       idsOfCommentLikedByUser,
+      payload: payload,
     };
     return user;
   }

--- a/src/community/community.controller.spec.ts
+++ b/src/community/community.controller.spec.ts
@@ -808,6 +808,7 @@ describe('CommunityController', () => {
     const mockReq = {
       user: {
         id: 1,
+        userName: 'test',
         idsOfPostsCreatedByUser: [],
         idsOfPostLikedByUser: [],
         idsOfCommentsCreatedByUser: [],
@@ -847,6 +848,7 @@ describe('CommunityController', () => {
     const mockReq = {
       user: {
         id: 1,
+        userName: 'test',
         idsOfPostsCreatedByUser: [],
         idsOfPostLikedByUser: [],
         idsOfCommentsCreatedByUser: [],

--- a/src/community/community.module.ts
+++ b/src/community/community.module.ts
@@ -43,17 +43,11 @@ import { TierRepository } from '../rank/tier.repository';
     AuthModule,
     UserModule,
     RankModule,
-    JwtModule.register({
-      secret: jwtConstants.jwtSecret,
-      signOptions: { expiresIn: jwtConstants.jwtExpiresIn },
-    }),
   ],
   controllers: [CommunityController],
   providers: [
     CommunityService,
     CommunityRepository,
-    AuthService,
-    JwtService,
     JwtStrategy,
     JwtRefreshStrategy,
     RankService,

--- a/src/community/community.repository.spec.ts
+++ b/src/community/community.repository.spec.ts
@@ -1,3 +1,4 @@
+import { AuthorizedUser } from './../auth/dto/auth.dto';
 import { User } from './../entities/User';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { CommunityRepository } from './community.repository';
@@ -182,12 +183,12 @@ describe('CommunityRepository', () => {
     it('SUCCESS : Should return an object : DeleteResult ', async () => {
       const mockDeleteResult = { raw: [], affected: 1 };
       const mockDeleteReCommentCriteria = {
-        user: new User(),
+        user: new AuthorizedUser(),
         id: 1,
         content: 'test',
+        userId: mockUserId,
         groupOrder: 1,
         depth: 1,
-        userId: mockUserId,
         postId: 1,
       };
 
@@ -210,7 +211,7 @@ describe('CommunityRepository', () => {
     it('SUCCESS : Should return object of UpdateResult', async () => {
       const mockUpdateResult = { raw: [], affected: 1 };
       const mockUpdateCommentCriteria = {
-        user: new User(),
+        user: new AuthorizedUser(),
         id: 1,
       };
       const mockContent = 'test';

--- a/src/community/community.service.spec.ts
+++ b/src/community/community.service.spec.ts
@@ -19,7 +19,6 @@ class MockCommunityRepository {
   updatePost = jest.fn();
   deletePost = jest.fn();
   getPostList = jest.fn();
-  getPostDatail = jest.fn();
   createOrDeletePostLike = jest.fn();
   searchPost = jest.fn();
   getPostsCreatedByUser = jest.fn();
@@ -715,6 +714,7 @@ describe('CommunityService', () => {
   describe('deleteComment()', () => {
     const mockUser = {
       id: 1,
+      userName: 'test',
       idsOfPostsCreatedByUser: [],
       idsOfPostLikedByUser: [],
       idsOfCommentsCreatedByUser: [1] as any,
@@ -836,6 +836,7 @@ describe('CommunityService', () => {
   describe('updateComment()', () => {
     const mockUser = {
       id: 1,
+      userName: 'test',
       idsOfPostsCreatedByUser: [],
       idsOfPostLikedByUser: [],
       idsOfCommentsCreatedByUser: [1] as any,

--- a/src/user/dto/createUser.dto.ts
+++ b/src/user/dto/createUser.dto.ts
@@ -1,0 +1,57 @@
+import { IsNumber, IsBoolean } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SignUpDto {
+  /**
+   * 유저의 github userId 입니다.
+   * @example 12345
+   */
+  @ApiProperty({
+    description: '유저의 github userId 입니다.',
+    example: 12345,
+    required: true,
+  })
+  @Type(() => Number)
+  @IsNumber()
+  readonly githubId: number;
+
+  /**
+   * 개발분야의 id 입니다.
+   * @example 1
+   */
+  @ApiProperty({
+    description: '개발분야의 id 입니다.',
+    example: 1,
+    required: true,
+  })
+  @Type(() => Number)
+  @IsNumber()
+  readonly fieldId: number;
+
+  /**
+   * 개발경력의 id 입니다.
+   * @example 1
+   */
+  @ApiProperty({
+    description: '개발경력의 id 입니다.',
+    example: 1,
+    required: true,
+  })
+  @Type(() => Number)
+  @IsNumber()
+  readonly careerId: number;
+
+  /**
+   * 유저가 한국인인지의 여부를 boolean으로 나타냅니다.
+   * @example true
+   */
+  @ApiProperty({
+    description: '유저가 한국인인지의 여부를 boolean으로 나타냅니다.',
+    example: true,
+    required: true,
+  })
+  @Type(() => Boolean)
+  @IsBoolean()
+  readonly isKorean: boolean;
+}

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -5,7 +5,7 @@ import { CommunityRepository } from './../community/community.repository';
 import { Test } from '@nestjs/testing';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
-import { UpdateMyPageDto } from './dto/mypage.dto';
+import { UpdateMyPageDto } from './dto/myPage.dto';
 
 class MockUserRepository {}
 class MockRankerProfileRepository {}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -11,7 +11,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { UserService } from './user.service';
-import { UpdateMyPageDto } from './dto/mypage.dto';
+import { UpdateMyPageDto } from './dto/myPage.dto';
 
 @ApiTags('User')
 @Controller('user')

--- a/src/user/user.repository.spec.ts
+++ b/src/user/user.repository.spec.ts
@@ -1,17 +1,21 @@
+import { User } from './../entities/User';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { QueryFailedError, TypeORMError } from 'typeorm';
-import { User } from '../entities/User';
-import { SignUpDto } from '../auth/dto/auth.dto';
+import { QueryFailedError, TypeORMError, UpdateResult } from 'typeorm';
+import { SignUpDto } from './dto/createUser.dto';
 import { UserRepository } from './user.repository';
 import { HttpException, HttpStatus } from '@nestjs/common';
-import { UpdateMyPageDto } from './dto/mypage.dto';
+import { UpdateMyPageDto } from './dto/myPage.dto';
 
-class MockRepository {
+class MockRepository extends User {
   create = jest.fn();
   save = jest.fn();
   findOneBy = jest.fn();
   update = jest.fn();
+
+  constructor() {
+    super();
+  }
 }
 
 describe('UserRepository', () => {
@@ -95,29 +99,37 @@ describe('UserRepository', () => {
       user.isKorean = signUpData.isKorean;
 
       jest.spyOn(mockRepository, 'create').mockReturnValue(user);
-      jest.spyOn(mockRepository, 'save').mockReturnValue(undefined);
+      jest.spyOn(mockRepository, 'save').mockReturnValue(user);
 
-      await userRepository.createUser(signUpData);
+      const result = await userRepository.createUser(signUpData);
 
+      expect(result).toEqual(user);
       expect(mockRepository.create).toHaveBeenCalledWith(signUpData);
       expect(mockRepository.save).toHaveBeenCalledWith(user);
     });
 
     it('FAILURE : Should handle a duplicate username when creating a user', async () => {
+      const user = new User();
+      user.githubId = signUpData.githubId;
+      user.fieldId = signUpData.fieldId;
+      user.careerId = signUpData.careerId;
+      user.isKorean = signUpData.isKorean;
+
       const mockError = new QueryFailedError(
         `test`,
         [],
         new Error('ER_DUP_ENTRY'),
       );
 
+      jest.spyOn(mockRepository, 'create').mockReturnValue(user);
       jest.spyOn(mockRepository, 'save').mockRejectedValue(mockError);
 
-      const existUser = await mockRepository.create(signUpData);
+      await mockRepository.create(signUpData);
       try {
-        await mockRepository.save(existUser);
+        await mockRepository.save(user);
       } catch (error) {
         try {
-          if (error.message === 'ER_DUP_ENTRY') {
+          if (error.name === 'QueryFailedError') {
             expect(error).toBeInstanceOf(QueryFailedError);
             throw new HttpException('EXISTING_USERNAME', HttpStatus.CONFLICT);
           } else {
@@ -133,7 +145,8 @@ describe('UserRepository', () => {
         }
       }
 
-      expect(mockRepository.save).toHaveBeenCalledWith(existUser);
+      expect(mockRepository.create).toHaveBeenCalledWith(signUpData);
+      expect(mockRepository.save).toHaveBeenCalledWith(user);
     });
 
     it('FAILURE : Should handle other errors when creating a user', async () => {
@@ -171,15 +184,39 @@ describe('UserRepository', () => {
         careerId: 1,
         isKorean: true,
       };
+      const updateResult = { affected: 1, raw: [] };
 
-      jest.spyOn(mockRepository, 'update');
+      jest.spyOn(mockRepository, 'update').mockResolvedValue(updateResult);
 
-      await userRepository.updateMyPage(userId, partialEntity);
+      const result = await userRepository.updateMyPage(userId, partialEntity);
 
+      expect(result).toEqual(updateResult);
       expect(mockRepository.update).toBeCalledWith(
         { id: userId },
         partialEntity,
       );
+    });
+  });
+
+  describe('updateUserRefreshToken()', () => {
+    it('SUCCESS : ', async () => {
+      // Given
+      const id = 1;
+      const hashedRefreshToken = 'test';
+      const updateResult = { affected: 1, raw: [] };
+      jest.spyOn(mockRepository, 'update').mockResolvedValue(updateResult);
+
+      // When
+      const result = await userRepository.updateUserRefreshToken(
+        id,
+        hashedRefreshToken,
+      );
+
+      // Then
+      expect(result).toEqual(updateResult);
+      expect(mockRepository.update).toHaveBeenCalledWith(id, {
+        hashedRefreshToken,
+      });
     });
   });
 });

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -1,9 +1,9 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { User } from '../entities/User';
-import { SignUpDto } from '../auth/dto/auth.dto';
+import { SignUpDto } from './dto/createUser.dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { UpdateMyPageDto } from './dto/mypage.dto';
+import { UpdateMyPageDto } from './dto/myPage.dto';
 
 @Injectable()
 export class UserRepository {
@@ -35,7 +35,7 @@ export class UserRepository {
     const user = this.userRepository.create(signUpData);
 
     try {
-      await this.userRepository.save(user);
+      return await this.userRepository.save(user);
     } catch (error) {
       console.log('createUser error: ', error);
       if (error.code === 'ER_DUP_ENTRY') {
@@ -50,10 +50,11 @@ export class UserRepository {
   }
 
   async updateMyPage(userId: number, partialEntity: UpdateMyPageDto) {
-    await this.userRepository.update({ id: userId }, partialEntity);
+    return await this.userRepository.update({ id: userId }, partialEntity);
   }
 
-  async updateUser(id: number, hashedRefreshToken: string) {
-    this.userRepository.update(id, { hashedRefreshToken });
+  // todo Add test code from this line
+  async updateUserRefreshToken(id: number, hashedRefreshToken: string) {
+    return await this.userRepository.update(id, { hashedRefreshToken });
   }
 }

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,4 +1,6 @@
-import { SignUpDto } from './../auth/dto/auth.dto';
+import { pbkdf2, pbkdf2Sync } from 'crypto';
+import { promisify } from 'util';
+import { SignUpDto } from './dto/createUser.dto';
 import { User } from './../entities/User';
 import { CommunityRepository } from './../community/community.repository';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -7,7 +9,7 @@ import { UserRepository } from './user.repository';
 import { RankerProfileRepository } from '../rank/rankerProfile.repository';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
-import { UpdateMyPageDto } from './dto/mypage.dto';
+import { UpdateMyPageDto } from './dto/myPage.dto';
 import { of, map, lastValueFrom } from 'rxjs';
 import { AxiosResponse, AxiosRequestConfig } from 'axios';
 
@@ -16,11 +18,13 @@ class MockUserRepository {
   getByUserId = jest.fn();
   createUser = jest.fn();
   updateMyPage = jest.fn();
+  updateUserRefreshToken = jest.fn();
 }
 
 class MockRankerProfileRepository {
   getMyPage = jest.fn();
   getUserTier = jest.fn();
+  getUserNameByUserId = jest.fn();
 }
 
 class MockCommunityRepository {
@@ -345,17 +349,199 @@ describe('UserService', () => {
         careerId: 1,
         isKorean: true,
       };
+      const updateResult = { affected: 1, raw: [] };
 
-      const userRepositoryUpdateMyPageSpy = jest.spyOn(
-        userRepository,
-        'updateMyPage',
-      );
+      jest
+        .spyOn(userRepository, 'updateMyPage')
+        .mockResolvedValue(updateResult as any);
 
-      await userService.updateMyPage(userId, partialEntity);
+      const result = await userService.updateMyPage(userId, partialEntity);
 
-      expect(userRepositoryUpdateMyPageSpy).toHaveBeenCalledWith(
+      expect(result).toEqual(updateResult);
+      expect(userRepository.updateMyPage).toHaveBeenCalledWith(
         userId,
         partialEntity,
+      );
+    });
+  });
+
+  describe('saveRefreshToken()', () => {
+    it('SUCCESS : Should save hashed refresh token for given user', async () => {
+      // Given;
+      const refreshToken = 'test';
+      const userId = 1;
+      const salt = process.env.REFRESH_SALT;
+      const iterations = +process.env.REFRESH_ITERATIONS;
+      const keylen = +process.env.REFRESH_KEYLEN;
+      const digest = process.env.REFRESH_DIGEST;
+      const mockPbkdf2 = jest.fn(pbkdf2);
+      const pbkdf2Promise = promisify(mockPbkdf2);
+      const key = await pbkdf2Promise(
+        refreshToken,
+        salt,
+        iterations,
+        keylen,
+        digest,
+      );
+      const updateResult = { affected: 1, raw: [] };
+
+      const hashedRefreshToken = key.toString('base64');
+
+      jest
+        .spyOn(userRepository, 'updateUserRefreshToken')
+        .mockResolvedValue(updateResult as any);
+
+      // When
+      const result = await userService.saveRefreshToken(refreshToken, userId);
+
+      // Then
+      expect(result).toEqual(updateResult);
+      expect(userRepository.updateUserRefreshToken).toHaveBeenCalledWith(
+        userId,
+        hashedRefreshToken,
+      );
+    });
+  });
+
+  describe('getUserIfRefreshTokenMatches()', () => {
+    const user = new User();
+    const id = 1;
+    user.id = id;
+    user.hashedRefreshToken = 'test';
+    const refreshToken = 'test';
+    const userName = 'test';
+
+    beforeEach(async () => {
+      jest.spyOn(userService, 'getById').mockResolvedValue(user);
+    });
+
+    it('SUCCESS : Should return an object id, userName}, if refreshToken is matched', async () => {
+      // Given
+      jest.spyOn(userService, 'verifyRefreshToken').mockResolvedValue(true);
+      jest
+        .spyOn(rankerProfileRepository, 'getUserNameByUserId')
+        .mockResolvedValue(userName);
+
+      const expectedResult = { id, userName };
+      // When
+      const result = await userService.getUserIfRefreshTokenMatches(
+        refreshToken,
+        id,
+      );
+
+      // Then
+      expect(result).toEqual(expectedResult);
+      expect(userService.getById).toHaveBeenCalledWith(id);
+      expect(userService.verifyRefreshToken).toHaveBeenCalledWith(
+        user.hashedRefreshToken,
+        refreshToken,
+      );
+      expect(rankerProfileRepository.getUserNameByUserId).toHaveBeenCalledWith(
+        id,
+      );
+    });
+
+    it('FAILURE : Should throw HttpException 401, if refreshToken in not matched', async () => {
+      // Given
+      jest.spyOn(userService, 'verifyRefreshToken').mockResolvedValue(false);
+
+      // When
+      try {
+        await userService.getUserIfRefreshTokenMatches(refreshToken, id);
+      } catch (error) {
+        // Then
+        expect(error).toBeInstanceOf(HttpException);
+        expect(error.status).toBe(HttpStatus.UNAUTHORIZED);
+        expect(error.message).toBe('UNAUTHORIZED');
+      }
+
+      expect(userService.getById).toHaveBeenCalledWith(id);
+      expect(userService.verifyRefreshToken).toHaveBeenCalledWith(
+        user.hashedRefreshToken,
+        refreshToken,
+      );
+    });
+  });
+
+  describe('verifyRefreshToken()', () => {
+    beforeAll(() => {
+      // set up process.env variables for testing
+      process.env.REFRESH_SALT = 'testSalt';
+      process.env.REFRESH_ITERATIONS = '1000';
+      process.env.REFRESH_KEYLEN = '64';
+      process.env.REFRESH_DIGEST = 'sha512';
+    });
+
+    afterAll(() => {
+      // clean up process.env variables after testing
+      delete process.env.REFRESH_SALT;
+      delete process.env.REFRESH_ITERATIONS;
+      delete process.env.REFRESH_KEYLEN;
+      delete process.env.REFRESH_DIGEST;
+    });
+
+    it('SUCCESS : Should return true, if refreshToken is matched ', async () => {
+      // Given
+      const currentRefreshToken = 'test';
+      const hashedRefreshToken = pbkdf2Sync(
+        currentRefreshToken,
+        process.env.REFRESH_SALT,
+        +process.env.REFRESH_ITERATIONS,
+        +process.env.REFRESH_KEYLEN,
+        process.env.REFRESH_DIGEST,
+      ).toString('base64');
+
+      // When
+      const result = await userService.verifyRefreshToken(
+        hashedRefreshToken,
+        currentRefreshToken,
+      );
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it('FAILURE : Should throw HttpException 401, if refreshToken is not matched', async () => {
+      // Given
+      const currentRefreshToken = 'test';
+      const lastRefreshToken = 'past';
+      const hashedRefreshToken = pbkdf2Sync(
+        lastRefreshToken,
+        process.env.REFRESH_SALT,
+        +process.env.REFRESH_ITERATIONS,
+        +process.env.REFRESH_KEYLEN,
+        process.env.REFRESH_DIGEST,
+      ).toString('base64');
+
+      // When
+      try {
+        await userService.verifyRefreshToken(
+          hashedRefreshToken,
+          currentRefreshToken,
+        );
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpException);
+        expect(error.status).toBe(HttpStatus.UNAUTHORIZED);
+        expect(error.message).toBe('UNAUTHORIZED');
+      }
+    });
+  });
+
+  describe('deleteRefreshToken()', () => {
+    it('SUCCESS : Should delete hashedRefreshToken In Database', async () => {
+      // Given
+      const id = 1;
+      const updateResult = { affected: 1, raw: [] };
+      jest
+        .spyOn(userRepository, 'updateUserRefreshToken')
+        .mockResolvedValue(updateResult as any);
+      // When
+      const result = await userService.deleteRefreshToken(id);
+
+      // Then
+      expect(result).toEqual(updateResult);
+      expect(userRepository.updateUserRefreshToken).toHaveBeenCalledWith(
+        id,
+        null,
       );
     });
   });


### PR DESCRIPTION
[구현한 기능]
- sign-in / sign-up API 수정 : 리프레쉬 토큰을 응답 헤더의 쿠키에 담아서 보내는 로직 추가, 생성된 refreshToken은 user 테이블에 hash하여 저장. hashing에는 crypto 사용(node.js 내장모듈)
- sign-out API : 로그아웃 요청 시 DB에 저장 된 hashedRefreshToken 삭제
- refresh API : 리프레시 토큰으로 엑세스 토큰 재발급 받는 API, refreshToken 만료기간이 절반 이상 지난 경우 자동 재발급
- refresh api swagger 설정
- req user객체에 userName추가
- guard 추가 : jwtGuard, jwtRefreshGuard 추가
- test코드 수정

[기타 변경사항]
- refresh token 관련 env 추가
- 요청 헤더의 쿠키를 읽기 위해 cookie parser 설정 추가
- 사용하지 않는 함수 삭제 및 auth-res.dto 수정
